### PR TITLE
Two new features: export format options and batch uploads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,5 +22,8 @@ TEMP_SIZE_LIMIT_GB=40      # Hard limit - trigger emergency cleanup
 # Local Data Dump
 # OVERTURE_DUMP_PATH=/path/to/your/dumps #uncomment and change if you want to change the default download locations
 
-# Large Dataset Processing
-# LARGE_DATASET_BATCH_SIZE=500000    # Records per batch for large dataset uploads if you want to experiment with batch sizes
+# Batch Processing Configuration  
+# BatchThreshold=1000000      # Features threshold to trigger batch mode
+# BatchSize=500000           # Records per batch when batch mode is used
+# SeedSize=1000              # Sample size for schema creation
+# AppendTimeout=7200         # Timeout for async append operations (2 hours)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This ETL pipeline allows you to query and extract Overture Maps data (such as ro
 
 ### Three commands
 - `agol-upload` - Upload your query to ArcGIS Online
-- `geojson-download` - Download your query in .geojson format
+- `export` - Export your query to multiple formats (GeoJSON, GeoPackage, File Geodatabase)
 - `overture-dump` - Caches your query (by country / theme) for continued use without need for multiple downloads.
 
 ### Features
@@ -59,22 +59,28 @@ The Python CLI has three main commands: uploading to AGOL, downloading as geojso
 - Or using module directly:
    `python -m o2agol.cli arcgis-upload roads --country afg`
 
-#### Export to GeoJSON:
-- Export Afghanistan roads (auto-filename: afg_roads.geojson):
-   `o2agol geojson-download roads --country afg`
+#### Export to Multiple Formats:
+- Export Afghanistan roads to GeoJSON (auto-filename: afg_roads.geojson):
+   `o2agol export roads --country lux`
    
-- Or specify output file:
-   `o2agol geojson-download roads afghanistan_roads.geojson --country afg`
+- Export to GeoPackage format:
+   `o2agol export buildings --country lux --format gpkg`
+   
+- Export raw Overture data (no AGOL transformations):
+   `o2agol export places --country lux --format gpkg --raw`
+   
+- Export to custom filename with format auto-detection:
+   `o2agol export roads lux_roads.gpkg --country lux`
 
 #### Download local dump for consistent use
 - Example with Afghanistan country parameter, detects and downloads local dump.
-   `o2agol overture-dump roads --country afg`
+   `o2agol overture-dump roads --country lux`
 
 ### Review options
 - If needed you can always review options with the --help argument.
 - `o2agol --help`
 - `o2agol arcgis-upload --help`
-- `o2agol geojson-download --help`
+- `o2agol export --help`
 - `o2agol overture-dump --help`
 
 ### List Queries
@@ -104,15 +110,17 @@ Use `configs/global.yml` with the `--country` parameter:
 - Metadata automatically applied based on configuration
 - Supports lines (roads), points (places), polygons (buildings), and multi-layer services
 
-### GeoJSON Export
-- Standards-compliant GeoJSON FeatureCollection files
-- Includes metadata with generation timestamp and feature counts  
-- Auto-generated filenames follow pattern: {iso3}_{query}.geojson
+### Data Export (Multiple Formats)
+- **GeoJSON**: Standards-compliant JSON format (default)
+- **GeoPackage (GPKG)**: SQLite-based format with multi-layer support  
+- **File Geodatabase (FGDB)**: ESRI format for ArcGIS workflows
+- Auto-generated filenames follow pattern: {iso3}_{query}.{extension}
 - Full Unicode support for international place names
+- Raw export option preserves original Overture schema
 
 ## List of required arguments
-To build your command, you need three elemenets:
-- Whether you are uploading to AGOL or downloading geojson
+To build your command, you need three elements:
+- Whether you are uploading to AGOL or exporting data
 - The query you are using
 - The country you are querying
 
@@ -164,10 +172,11 @@ Below is a list of optional arguments. Useful if you need to tailor your command
 - `o2agol arcgis-upload education --country pakistan --log-to-file` - Pakistan education facilities with logging
 - `o2agol arcgis-upload buildings --country "south africa" --dry-run` - South Africa buildings (test mode)
 
-### GeoJSON Export:
-- `o2agol geojson-download roads --country afg` - Export Afghanistan roads (auto-filename: afg_roads.geojson)
-- `o2agol geojson-download health usa_health.geojson --country usa --limit 1000` - USA health facilities to specific file
-- `o2agol geojson-download education --country pak --use-bbox --limit 100` - Fast export with bounding box
+### Data Export:
+- `o2agol export roads --country afg` - Export Afghanistan roads to GeoJSON (auto-filename: afg_roads.geojson)
+- `o2agol export health usa_health.gpkg --country usa --limit 1000` - USA health facilities to GeoPackage
+- `o2agol export education --country pak --format gpkg --use-bbox --limit 100` - Fast export with bounding box to GPKG
+- `o2agol export buildings --country ind --format fgdb --raw` - Raw building data to File Geodatabase
 
 ## Development status
 Please note development began in August 2025 and is ongoing. The pipeline works with all the options described below. The only issue is when running large polygon datasets >8 million. Sometimes there are hang ups with ArcGIS Online during appending the feature layer. We tried to mitigate this by giving the user multiple export options, parameter options, and batch processing. 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Overture Maps Data to GeoJSON and ArcGIS Online Pipeline
+# OvertureLink
+## Flexible Overture data ingestion for AGOL and export workflows
 
 ## Purpose
 Choose your Overture query, specify the country, then you're done!
 
-This cloud-native ETL pipeline allows you to query and extract Overture Maps data (such as roads, buildings) to upload to ArcGIS Online, download as .geojson for any GIS software, or save as a local dump for continual use. This pipeline supports 176 countries worldwide with its country/ISO database, allows you to use pre-built queries or your own custom queries, and is designed to align with Overture's monthly releases.
-
-### Development status
-Please note development is ongoing. The pipeline works with all the options described below. The only issue is when running large polygon datasets >8 million. Sometimes there are hang ups with ArcGIS Online during appending. We're investigating the best options to reduce these errors, such as setting the right append parameters and testing upload as a FGDB.
+This ETL pipeline allows you to query and extract Overture Maps data (such as roads, buildings) to upload to ArcGIS Online, download as .geojson for any GIS software, or save as a local dump for continual use. This pipeline supports 176 countries worldwide with its country/ISO database, allows you to use pre-built queries or your own custom queries, and is designed to align with Overture's monthly releases. This pipeline was originally built to support the World Bank's distributed data across ArcGIS Hubs, but should work for other work flows. 
 
 ### Three commands
 - `agol-upload` - Upload your query to ArcGIS Online
@@ -16,6 +14,7 @@ Please note development is ongoing. The pipeline works with all the options desc
 ### Features
 - Automatic AGOL discovery: The pipeline will either create a new feature layer or use truncate and append based on whether or not a feature layer already exists. 
 - Online and cache query: Query from Overture directly, or download a dump for consecutive uses.
+- Large files can be run in batch mode to assist with uploading to AGOL.
 - Robust options: Custom configs, feature limits, debug logging, and more.
 
 ## Pipeline Overview
@@ -88,18 +87,11 @@ And add you own query in the global config (`configs\global.yml`)
 
 ## Config
 
-### Global Configuration (Recommended)
+### Global Configuration
 Use `configs/global.yml` with the `--country` parameter:
 - **Country Selection**: Specify any country using name, ISO2, or ISO3 code (supports 176 countries)
 - **Dynamic Processing**: Country metadata and bounding boxes are automatically loaded
 - **Template System**: All titles, descriptions, and metadata are dynamically generated
-
-### Legacy Country-Specific Configs
-`configs/<country>.yml` files are still supported:
-- `overture_release`: "latest" or a specific date
-- `selector`: ISO2 country code 
-- `targets`: roads/buildings with layer titles, item IDs, filters
-- `mode`: initial/overwrite/append
 
 ### Clip modes
 - Overture Division Clip: precise geometric clip with bbox pre-filtering. Use `--use-divisions` for production (default).
@@ -136,10 +128,10 @@ There are sets of queries prebuilt that you can find below and in the configs fi
 - `markets` - Retail facilities. Creates multi-layer service with both geometry types.
 
 #### Points Only
-- `places` - All points of interest (unfiltered places)
+- `places` - All points of interest 
 
 #### Polygons Only
-- `buildings` - Building footprints (all building polygons) 
+- `buildings` - Building footprints
 
 ### Choosing a Country
 
@@ -177,23 +169,21 @@ Below is a list of optional arguments. Useful if you need to tailor your command
 - `o2agol geojson-download health usa_health.geojson --country usa --limit 1000` - USA health facilities to specific file
 - `o2agol geojson-download education --country pak --use-bbox --limit 100` - Fast export with bounding box
 
-### Troubleshooting
+## Development status
+Please note development began in August 2025 and is ongoing. The pipeline works with all the options described below. The only issue is when running large polygon datasets >8 million. Sometimes there are hang ups with ArcGIS Online during appending the feature layer. We tried to mitigate this by giving the user multiple export options, parameter options, and batch processing. 
 
-#### Common Issues
+We're investigating the best options to reduce these errors, such as setting the right append parameters and testing uploads as different formats (GeoJson, FGDB, Geopackage). This will require extensive testing. Recently, we've had the most success uploading in gpkg format in batches of 500,000 (settings in your .env file can be changed).
+
+### Troubleshooting
 - Validation errors: Re-download with `--force-download`
 - Memory errors: Reduce `DUMP_MAX_MEMORY` or use `--limit`
 - Disk space: Use `o2agol list-dumps` to check space usage
-- Larger data uploads (8+ million features) can sometimes hang on the upload to ArcGIS. We are actively trying to figure out the best way to deal with this.
 
-#### Performance Tips  
-- Use `--use-bbox` for development (faster spatial filtering)
-- Increase `DUMP_MAX_MEMORY` if you have available RAM
-- Download dumps to SSD for better query performance
-- Use `--limit` for development to reduce processing time
+## Planned for future
+- More testing for best way of appending large datasets (>8 million).
+- More transformation options for users.
+- Interactive CLI for easier downloading.
 
-## CI/CD
-- `ci.yml`: lint, type-check, unit tests on PR/main.
-- `run-pipeline.yml`: manual (`workflow_dispatch`) or schedule (cron). Uses environment secrets.
 
 ## Sources
 - Overture documentation: https://docs.overturemaps.org/guides/divisions/

--- a/src/o2agol/cleanup.py
+++ b/src/o2agol/cleanup.py
@@ -1,4 +1,4 @@
-"""Temporary file management for cloud-native pipeline operations."""
+"""Temporary file management for pipeline operations."""
 
 from __future__ import annotations
 

--- a/src/o2agol/cli.py
+++ b/src/o2agol/cli.py
@@ -14,6 +14,9 @@ import typer
 import yaml
 from dotenv import load_dotenv
 
+# Load environment variables BEFORE importing local modules that use them
+load_dotenv()
+
 from .cleanup import full_cleanup_check, register_cleanup_handlers
 from .config import Config
 from .config.settings import PipelineLogger, LogContext
@@ -23,8 +26,6 @@ from .dump_manager import DumpManager, DumpConfig
 from .publish import publish_or_update
 from .transform import normalize_schema
 from .types import StagingFormat
-
-load_dotenv()
 
 app = typer.Typer(help="Overture to AGOL pipeline")
 

--- a/src/o2agol/export.py
+++ b/src/o2agol/export.py
@@ -1,0 +1,335 @@
+"""
+Export functionality for Overture Maps data in multiple formats.
+
+This module provides unified export capabilities to GeoJSON, GeoPackage (GPKG), 
+and File Geodatabase (FGDB) formats with optional raw data preservation.
+"""
+
+import json
+import logging
+import tempfile
+from datetime import datetime
+from pathlib import Path
+from typing import Union, Dict, Optional
+from enum import Enum
+
+import geopandas as gpd
+import fiona
+
+logger = logging.getLogger(__name__)
+
+
+class ExportFormat(str, Enum):
+    """Supported export formats for Overture data"""
+    GEOJSON = "geojson"
+    GPKG = "gpkg"
+    FGDB = "fgdb"
+    
+    @classmethod
+    def from_extension(cls, path: str) -> 'ExportFormat':
+        """Infer format from file extension"""
+        ext = Path(path).suffix.lower()
+        mapping = {
+            '.geojson': cls.GEOJSON,
+            '.json': cls.GEOJSON,
+            '.gpkg': cls.GPKG,
+            '.gdb': cls.FGDB
+        }
+        return mapping.get(ext, cls.GEOJSON)
+
+
+def export_data(
+    data: Union[gpd.GeoDataFrame, Dict[str, gpd.GeoDataFrame]],
+    output_path: str,
+    target_name: str,
+    export_format: str = "geojson",
+    raw_export: bool = False,
+    include_metadata: bool = True
+) -> None:
+    """
+    Export geospatial data to specified format.
+    
+    Args:
+        data: GeoDataFrame or dict of GeoDataFrames (multi-layer)
+        output_path: Output file path
+        target_name: Target data type for metadata
+        export_format: Export format (geojson, gpkg, fgdb)
+        raw_export: If True, indicates raw Overture data
+        include_metadata: Whether to include metadata
+    """
+    format_enum = ExportFormat(export_format.lower())
+    
+    # Validate output path
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    
+    # Route to format-specific handler
+    if format_enum == ExportFormat.GEOJSON:
+        _export_to_geojson(data, output_path, target_name, raw_export, include_metadata)
+    elif format_enum == ExportFormat.GPKG:
+        _export_to_gpkg(data, output_path, target_name, raw_export, include_metadata)
+    elif format_enum == ExportFormat.FGDB:
+        _export_to_fgdb(data, output_path, target_name, raw_export, include_metadata)
+    else:
+        raise ValueError(f"Unsupported export format: {export_format}")
+    
+    logger.info(f"Successfully exported to {output_path} ({export_format})")
+
+
+def _export_to_geojson(
+    data: Union[gpd.GeoDataFrame, Dict[str, gpd.GeoDataFrame]],
+    output_path: Path,
+    target_name: str,
+    raw_export: bool,
+    include_metadata: bool
+) -> None:
+    """Export to GeoJSON format - preserve existing functionality"""
+    
+    # Handle both single GeoDataFrame and multi-layer dict
+    if isinstance(data, dict):
+        # Multi-layer: combine all features
+        all_features = []
+        layer_counts = {}
+        
+        for layer_name, gdf in data.items():
+            # Use standard geopandas export - data should already be clean
+            layer_features = gdf.to_json()
+            layer_data = json.loads(layer_features)
+            
+            # Add layer identifier to each feature
+            for feature in layer_data.get("features", []):
+                feature["properties"]["layer"] = layer_name
+            
+            all_features.extend(layer_data.get("features", []))
+            layer_counts[layer_name] = len(layer_data.get("features", []))
+        
+        # Create combined GeoJSON
+        geojson_data = {
+            "type": "FeatureCollection",
+            "features": all_features,
+        }
+        
+        if include_metadata:
+            geojson_data["metadata"] = {
+                "generated": datetime.utcnow().isoformat(),
+                "source": "overture-agol-pipeline",
+                "target": target_name,
+                "data_type": "raw_overture" if raw_export else "agol_transformed",
+                "layers": layer_counts,
+                "total_count": len(all_features)
+            }
+    else:
+        # Single GeoDataFrame - use standard geopandas export
+        features_json = data.to_json()
+        features_data = json.loads(features_json)
+        
+        geojson_data = {
+            "type": "FeatureCollection",
+            "features": features_data.get("features", []),
+        }
+        
+        if include_metadata:
+            geojson_data["metadata"] = {
+                "generated": datetime.utcnow().isoformat(),
+                "source": "overture-agol-pipeline", 
+                "target": target_name,
+                "data_type": "raw_overture" if raw_export else "agol_transformed",
+                "count": len(features_data.get("features", []))
+            }
+    
+    # Write with proper encoding and formatting
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(geojson_data, f, indent=2, ensure_ascii=False)
+    
+    # Validate written file
+    if not _validate_geojson_file(str(output_path)):
+        raise ValueError(f"Generated GeoJSON file is invalid: {output_path}")
+    
+    logger.info(f"GeoJSON export completed: {len(geojson_data['features']):,} features written to {output_path}")
+
+
+def _export_to_gpkg(
+    data: Union[gpd.GeoDataFrame, Dict[str, gpd.GeoDataFrame]],
+    output_path: Path,
+    target_name: str,
+    raw_export: bool,
+    include_metadata: bool
+) -> None:
+    """Export to GeoPackage format with layer support"""
+    
+    if isinstance(data, dict):
+        # Multi-layer export (e.g., education = places + buildings)
+        for i, (layer_name, gdf) in enumerate(data.items()):
+            mode = 'w' if i == 0 else 'a'  # Write first, append rest
+            layer_table = f"{target_name}_{layer_name}" if not raw_export else layer_name
+            
+            logger.debug(f"Exporting layer '{layer_table}' with {len(gdf)} features")
+            gdf.to_file(output_path, driver='GPKG', layer=layer_table, mode=mode)
+    else:
+        # Single layer export
+        layer_name = target_name if not raw_export else "features"
+        logger.debug(f"Exporting single layer '{layer_name}' with {len(data)} features")
+        data.to_file(output_path, driver='GPKG', layer=layer_name)
+    
+    # Add metadata if requested
+    if include_metadata:
+        _add_gpkg_metadata(output_path, target_name, raw_export)
+
+
+def _export_to_fgdb(
+    data: Union[gpd.GeoDataFrame, Dict[str, gpd.GeoDataFrame]],
+    output_path: Path,
+    target_name: str,
+    raw_export: bool,
+    include_metadata: bool
+) -> None:
+    """Export to ESRI File Geodatabase format"""
+    
+    # Validate FGDB driver availability
+    if 'FileGDB' not in fiona.supported_drivers:
+        raise RuntimeError("FileGDB driver not available. Please install GDAL with FileGDB support.")
+    
+    # Create .gdb directory structure (remove if exists)
+    if output_path.exists():
+        import shutil
+        shutil.rmtree(output_path)
+    
+    if isinstance(data, dict):
+        # Multi-layer export
+        for i, (layer_name, gdf) in enumerate(data.items()):
+            fc_name = f"{target_name}_{layer_name}" if not raw_export else layer_name
+            # Prepare for FGDB compatibility (field name limits)
+            gdf = _prepare_for_fgdb(gdf)
+            
+            mode = 'w' if i == 0 else 'a'
+            logger.debug(f"Exporting feature class '{fc_name}' with {len(gdf)} features")
+            gdf.to_file(output_path, driver='FileGDB', layer=fc_name, mode=mode)
+    else:
+        # Single feature class
+        fc_name = target_name if not raw_export else "features"
+        data = _prepare_for_fgdb(data)
+        logger.debug(f"Exporting feature class '{fc_name}' with {len(data)} features")
+        data.to_file(output_path, driver='FileGDB', layer=fc_name)
+
+
+def _prepare_for_fgdb(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
+    """Prepare GeoDataFrame for FGDB export (field name limits, etc.)"""
+    gdf = gdf.copy()
+    
+    # Truncate column names to 64 characters (FGDB limit)
+    rename_map = {}
+    for col in gdf.columns:
+        if col != 'geometry' and len(col) > 64:
+            new_name = col[:64]
+            logger.warning(f"Truncating field name '{col}' to '{new_name}' for FGDB compatibility")
+            rename_map[col] = new_name
+    
+    if rename_map:
+        gdf = gdf.rename(columns=rename_map)
+    
+    return gdf
+
+
+def _add_gpkg_metadata(output_path: Path, target_name: str, raw_export: bool) -> None:
+    """Add metadata table to GeoPackage"""
+    import sqlite3
+    
+    conn = sqlite3.connect(output_path)
+    cursor = conn.cursor()
+    
+    # Create metadata table
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+    """)
+    
+    # Insert metadata
+    metadata = {
+        'created_at': datetime.now().isoformat(),
+        'target_name': target_name,
+        'data_type': 'raw_overture' if raw_export else 'agol_transformed',
+        'source': 'Overture Maps Foundation',
+        'pipeline': 'Overture-ArcGIS-Pipeline'
+    }
+    
+    for key, value in metadata.items():
+        cursor.execute("INSERT OR REPLACE INTO metadata (key, value) VALUES (?, ?)", (key, value))
+    
+    conn.commit()
+    conn.close()
+
+
+def _validate_geojson_file(filepath: str) -> bool:
+    """Validate that exported GeoJSON file is properly formatted."""
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+        
+        # Basic GeoJSON structure validation
+        if not isinstance(data, dict):
+            logger.error("Invalid GeoJSON: root must be an object")
+            return False
+        
+        if data.get("type") != "FeatureCollection":
+            logger.error("Invalid GeoJSON: type must be 'FeatureCollection'")
+            return False
+        
+        if "features" not in data:
+            logger.error("Invalid GeoJSON: missing 'features' property")
+            return False
+        
+        if not isinstance(data["features"], list):
+            logger.error("Invalid GeoJSON: features must be an array")
+            return False
+        
+        return True
+    except Exception as e:
+        logger.error(f"GeoJSON validation failed: {e}")
+        return False
+
+
+def generate_export_filename(query: str, country: str = None, export_format: str = "geojson", raw_export: bool = False) -> str:
+    """
+    Generate default export filename based on format
+    
+    Args:
+        query: Query name (e.g., 'education', 'roads')
+        country: Country identifier (ISO2, ISO3, or name)
+        export_format: Export format (geojson, gpkg, fgdb)
+        raw_export: Whether this is a raw export
+        
+    Returns:
+        Generated filename string
+    """
+    if country:
+        from .config.countries import CountryRegistry
+        try:
+            country_info = CountryRegistry.get_country(country)
+            if country_info:
+                iso3 = country_info.iso3.lower()
+            else:
+                # Fallback if country not found
+                iso3 = country.lower()
+                logger.warning(f"Country '{country}' not found in registry, using fallback")
+        except Exception:
+            iso3 = country.lower()
+    else:
+        iso3 = "unknown"
+    
+    # Add suffix for raw exports
+    suffix = "_raw" if raw_export else ""
+    
+    # Map formats to extensions
+    extensions = {
+        "geojson": "geojson",
+        "gpkg": "gpkg", 
+        "fgdb": "gdb"
+    }
+    
+    extension = extensions.get(export_format, "geojson")
+    filename = f"{iso3}_{query}{suffix}.{extension}"
+    
+    logger.info(f"Generated export filename: {filename}")
+    return filename


### PR DESCRIPTION
I've released two new features that will help users have a more flexible and stable experience. 

1) Export: this replaces the `download-geojson` command. Users can now export in geojson, gpkg, or gfdb. You can also choose to download the raw file from the query or let it go through the transform process we use.

2) Batch uploads: we've been having issues with large file uploads to AGOL (>8 million) with queries such as buildings. This option now switches the append via item function to append in batches. This can help with troublesome uploads. I'll continue to investigate the best way to deal with large uploads, as they can be finicky with AGOL. 